### PR TITLE
Added empty travis.yml to gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+install: true
+script: true


### PR DESCRIPTION
This prevents building errors on branches forked from gh-pages. The gh-pages branch itself should be ignored by TravisCI by default.
