### PR TITLE
Proposal: Integration test checking examples on apiblueprint.org website

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -10,13 +10,13 @@ handleError = (err) ->
   process.exit 1
 
 
-gulp.task 'test', ->
+gulp.task 'unit-test', ->
   gulp.src('tests/*-test.*', read: false)
     .pipe(mocha(reporter: 'spec', grep: yargs.argv.grep))
     .on 'error', handleError
 
 
-gulp.task 'forgiving-test', ->
+gulp.task 'forgiving-unit-test', ->
   gulp.src('tests/*-test.*')
     .pipe(mocha(reporter: 'dot', compilers: 'coffee:coffee-script'))
     .on 'error', (err) ->
@@ -25,10 +25,10 @@ gulp.task 'forgiving-test', ->
       @emit 'end'
 
 
-# gulp.task 'integration-test', ->
-#   gulp.src('tests/run-integration-tests.coffee')
-#   .pipe(mocha(reporter: 'spec', grep: yargs.argv.grep))
-#   .on 'error', handleError
+gulp.task 'integration-test', ->
+  gulp.src('tests/integration/*-test.*')
+    .pipe(mocha(reporter: 'spec', grep: yargs.argv.grep))
+    .on 'error', handleError
 
 
 gulp.task 'lint', ->
@@ -48,12 +48,12 @@ gulp.task 'forgiving-lint', ->
       @emit 'end'
 
 
-gulp.task 'citest', ['test'] #, 'integration-test']
+gulp.task 'test', ['unit-test', 'integration-test']
 
 
 gulp.task 'tdd', ->
-  gulp.watch 'lib/*',  ['forgiving-lint', 'forgiving-test']
-  gulp.watch 'tests/*-test.*', ['forgiving-lint', 'forgiving-test']
+  gulp.watch 'lib/*',  ['forgiving-lint', 'forgiving-unit-test']
+  gulp.watch 'tests/*-test.*', ['forgiving-lint', 'forgiving-unit-test']
 
 
 gulp.task 'default', ['test']

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "gulp-coffeelint": "~0.3.2",
     "gulp-watch": "~0.6.8",
     "yargs": "~1.2.1",
-    "sinon": "~1.9.1"
+    "sinon": "~1.9.1",
+    "htmlparser2": ""
   }
 }

--- a/tests/blueprint-test.coffee
+++ b/tests/blueprint-test.coffee
@@ -4,7 +4,7 @@ require 'mocha'
 {parse} = require '../lib/blueprint'
 
 
-describe "parse", ->
+describe "Parsing", ->
 
   describe "When I send in the blueprint without API name", ->
     error = undefined
@@ -14,5 +14,5 @@ describe "parse", ->
         error = err
         done null
 
-    it 'I do not got an error', ->
+    it 'I do not get an error', ->
       assert.notOk error

--- a/tests/integration/apiblueprintorg-test.coffee
+++ b/tests/integration/apiblueprintorg-test.coffee
@@ -1,0 +1,84 @@
+require 'mocha'
+Test = require('mocha').Test
+http = require 'http'
+htmlparser = require 'htmlparser2'
+{assert} = require 'chai'
+
+{parse} = require '../../lib/blueprint'
+
+
+download = (cb) ->
+  html = ''
+  err = undefined
+  req = http.request
+    host: 'apiblueprint.org'
+    port: 80
+    path: ''
+    method: 'GET'
+  , (res) ->
+    res.setEncoding 'utf8'
+    res.on 'data', (chunk) -> html += chunk
+    res.on 'error', (e) -> err = e
+    res.on 'end', -> cb err, html
+  req.end()
+
+parseExamples = (html, cb) ->
+  err = undefined
+  blueprints = []
+  asts = []
+
+  writeBlueprint = false
+  writeAst = false
+
+  parser = new htmlparser.Parser
+    onopentag: (name, attrs) ->
+      if name == 'code'
+        writeBlueprint = (attrs.class == 'markdown')
+        writeAst = (attrs.class == 'ast')
+    ontext: (text) ->
+      if writeBlueprint
+        blueprints.push text
+      else if writeAst
+        asts.push JSON.parse text
+    onclosetag: (name) ->
+      writeBlueprint = false
+      writeAst = false
+    onerror: (e) ->
+      err = e
+    onend: ->
+      cb err, ({blueprint, ast: asts[i]} for blueprint, i in blueprints)
+
+  parser.write html
+  parser.end()
+
+
+suite = describe "apiblueprint.org", ->
+  examples = undefined
+
+  before (done) ->
+    download (err, html) ->
+      if err then return done err
+      parseExamples html, (err, result) ->
+        examples = result
+        if err then return done err
+
+        # We add tests dynamically here, because we can't use `examples` variable
+        # out of `describe`s and `it`s to iterate over it - it's not filled yet.
+        # Also, `describe`s are not async and we can't have nested `it`s.
+        for example, i in examples
+          ast = undefined
+
+          suite.addTest new Test "Example ##{i + 1} has parseable blueprint", (done) ->
+            parse example.blueprint, (err, result) ->
+              assert.notOk err
+              ast = result.ast
+              done()
+
+          suite.addTest new Test "Example ##{i + 1} has the right AST", ->
+            assert.deepEqual ast, example.ast
+
+        done()
+
+  it "has examples", ->
+    assert examples.length > 0
+    # this one just makes sure dynamic tests added above will be executed


### PR DESCRIPTION
Builds on top of #19.

https://trello.com/c/ObThuTMy/1755-proper-testsuite-for-api-blueprint-api-app

Added integration test checking whether examples from apiblueprint.org website pass through correctly. This should prevent things like #16.
