### PR TITLE
[Index] Remove left-over Snow Crash reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@ Delete a message. **Warning:** This action **permanently** removes the message f
       <h2 class="page__title">Get Started</h2>
       <p class="started__texts--subheading">Use the reference API Blueprint parser – <a href="https://github.com/apiaryio/drafter">Drafter</a> or one of its <a href="#bindings">bindings</a>.</p>
       <section>
-        <h3>Get Snow Crash</h3>
+        <h3>Get Drafter</h3>
         <pre><code class="pre">$ brew install --HEAD \
   https://raw.github.com/apiaryio/drafter/master/tools/homebrew/drafter.rb</code></pre>
         <p class="subnotes">


### PR DESCRIPTION
The instructions are for Drafter so it makes no sense to say "Get Snow Crash".