### PR TITLE
[package.json] Update protagonist to ~> 0.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "media-typer": "",
     "morgan": "",
     "node-hipchat": "",
-    "protagonist": "~0.19.3",
+    "protagonist": "~0.20.1",
     "qs": "",
     "winston": "git://github.com/apiaryio/winston.git#production"
   },


### PR DESCRIPTION
This pull request updates protagonist, which inturn allows the support for API Blueprint format 1A9.

Before:


![screen shot 2015-06-25 at 10 33 44](https://cloud.githubusercontent.com/assets/44164/8361109/002ac3d0-1b26-11e5-86cf-0160fded1d2b.png)

After:

```json
{
  "ast": {
    "_version": "3.0",
    "metadata": [],
    "name": "",
    "description": "",
    "element": "category",
    "resourceGroups": [
      {
        "name": "",
        "description": "",
        "resources": [
          {
            "element": "resource",
            "name": "Prefer/Unprefer artist",
            "description": "",
            "uriTemplate": "/api/artists/{id}/prefer",
            "model": {},
            "parameters": [],
            "actions": [
              {
                "name": "Prefer/Unprefer artist",
                "description": "",
                "method": "POST",
                "parameters": [],
                "attributes": {
                  "relation": "",
                  "uriTemplate": "/api/artists/{id}/prefer"
...
```

This is a dependant task for https://github.com/apiaryio/Paw-APIBlueprintImporter/issues/9.