### PR TITLE
Add Bluepaste to the tooling section

### DIFF
--- a/index.html
+++ b/index.html
@@ -766,6 +766,13 @@ Delete a message. **Warning:** This action **permanently** removes the message f
    --><p class="tooling__text">Gulp tasks for writing large API Blueprints efficiently</p>
       </div></li>
 
+    <li class="tooling__item"><div class="tooling__item--wrap">
+      <span class="tooling__ico"><span class="tooling__ico__logo tooling__ico--construction"></span></span><!--
+   --><h3 class="tooling__title"><a href="https://bluepaste.herokuapp.com"
+           class="block larger"><span class="block">Bluepaste</span><span class="tooling__link"></span></a> <span class="block smaller">API Blueprint Focus Booster</span></h3><!--
+   --><p class="tooling__text">API Blueprint pastebin service.</p>
+      </div></li>
+
       <li class="tooling__item"><div class="tooling__item--wrap">
         <span class="tooling__ico"><span class="tooling__ico__logo tooling__ico--construction"></span></span><!--
      --><h3 class="tooling__title"><a href="https://github.com/apiaryio/swagger2blueprint" class="block larger"><span class="block">swagger2blueprint</span><span class="tooling__link"></span></a> <span class="block smaller">Converter</span></h3><!--


### PR DESCRIPTION
Weekend project: Bluepaste, it's an API Blueprint pastebin service, it can be found at https://bluepaste.herokuapp.com.

Secret features, content-negotiation on all resources supporting a variety of content types.

```shell
$ curl -H 'Accept: text/vnd.apiblueprint+markdown' https://bluepaste.herokuapp.com/1ddec480
$ curl -H 'Accept: application/vnd.apiblueprint.ast.raw+json' https://bluepaste.herokuapp.com/1ddec480
$ curl -H 'Accept: application/vnd.siren+json' https://bluepaste.herokuapp.com/1ddec480
$ curl -H 'Accept: application/hal+json' https://bluepaste.herokuapp.com/1ddec480
$ curl -H 'Accept: application/json' https://bluepaste.herokuapp.com/1ddec480
$ curl -H 'Accept: text/html' https://bluepaste.herokuapp.com/1ddec480
```