### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-apiblueprint.org


### PR DESCRIPTION
This removes this website from the apiblueprint.org domain, being replaced by https://github.com/apiaryio/apiblueprint.org/pull/6